### PR TITLE
AMMA 2024 Postponed

### DIFF
--- a/amma.qmd
+++ b/amma.qmd
@@ -4,7 +4,14 @@ title: ""
 
 ## AMMA 2024: Abstract Methods in Multivariate Algorithmics
 
+::: {.callout-important title="Postponed"}
+
+**AMMA 2024 is now postponed to 2025 due to international changes in the organizing committee**
+
+:::
+
 ![](UF_Skyline.webp)
+
 
 ### About
 
@@ -38,19 +45,6 @@ The topics may include but are not limited to:
 - Abstract models of computation appropriate to truly linear FPT (O(n) + f(k)) algorithmics
 
 - Abstract models of graphs arising from data points plus metric knobs, and their natural decompositions.
-
-#### Dates
-
-August 12-16, 2024
-
-#### Abstract Submission
-
-[Submit here](https://airtable.com/appRyZLo3hFzz1iCd/shrsiKE3Dgcy1BTi2)
-
-#### Recommended Hotels
-
-- [Holiday Inn Gainesville-University Ctr](https://www.ihg.com/holidayinn/hotels/us/en/gainesville/gnvuc/hoteldetail?fromRedirect=true&qSrt=sBR&qIta=99618783&icdv=99618783&glat=META_hpa_paid_US_desktop_GNVUC_mapresults_4_USD_2024-08-12_selected_12260711232__FALSE_KNGNIDSLS&qSlH=GNVUC&qRms=1&qAdlt=2&qChld=0&qCiD=12&qCiMy=072024&qCoD=16&qCoMy=072024&qrtPt=177.44&setPMCookies=true&qSlRc=KNGN&qRtP=IDSLS&qSHBrC=HI&qDest=1250%20W.%20University%20Ave,%20Gainesville,%20FL,%20US&qSlRp=KNGNIDSLS&hmGUID=92fe9054-69c6-4a5d-94f5-54b2583d1ff3&gclid=CjwKCAjwuJ2xBhA3EiwAMVjkVGyzbBOCMM8HgrXfrQheNF2hc6ELmUfd_ETHp0XB0hRPvDYYkQktuRoC6owQAvD_BwE&cm_mmc=hpa_paid_US_desktop_GNVUC_mapresults_4_USD_2024-08-12_selected_12260711232__FALSE_KNGNIDSLS&srb_u=1)
-- [AC Hotel Gainesville Downtown](https://www.marriott.com/en-us/hotels/gnvac-ac-hotel-gainesville-downtown/overview/)
 
 #### Organizers
 


### PR DESCRIPTION
removed registration and date information as well as a callout box announcing that AMMA 2024 is postponed for 2025