### PR TITLE
Added back missing images

### DIFF
--- a/publications/diagrameqns/diagrameqns.md
+++ b/publications/diagrameqns/diagrameqns.md
@@ -18,6 +18,8 @@ categories:
     - Multiphysics
 ---
 
+![](./fig1.jpg){width=50%}
+
 ## Abstract
 
 Presenting systems of differential equations in the form of diagrams has become common in certain parts of physics, especially electromagnetism and computational physics. In this work, we aim to put such use of diagrams on a firm mathematical footing, while also systematizing a broadly applicable framework to reason formally about systems of equations and their solutions. Our main mathematical tools are category-theoretic diagrams, which are well known, and morphisms between diagrams, which have been less appreciated. As an application of the diagrammatic framework, we show how complex, multiphysical systems can be modularly constructed from basic physical principles. A wealth of examples, drawn from electromagnetism, transport phenomena, fluid mechanics, and other fields, is included.

--- a/publications/diagrampresentations/diagrampresentations.md
+++ b/publications/diagrampresentations/diagrampresentations.md
@@ -12,6 +12,8 @@ categories:
     - Category-theoretic diagrams
 ---
 
+![](./fig1.png)
+
 ## Abstract
 
 Lifts of categorical diagrams D:𝖩→𝖷 against discrete opfibrations π:𝖤→𝖷 can be interpreted as presenting solutions to systems of equations. With this interpretation in mind, it is natural to ask if there is a notion of equivalence of diagrams D≃D′ that precisely captures the idea of the two diagrams "having the same solutions''. We give such a definition, and then show how the localisation of the category of diagrams in 𝖷 along such equivalences is isomorphic to the localisation of the slice category 𝖢𝖺𝗍/𝖷 along the class of initial functors. Finally, we extend this result to the 2-categorical setting, proving the analogous statement for any locally presentable 2-category in place of 𝖢𝖺𝗍.


### PR DESCRIPTION
Images stored in title blocks don't seem to generate so I've added back the images themselves in regular markdown.