### PR TITLE
add ubuntu upgrade before installing tex dependencies

### DIFF
--- a/.github/workflows/build_quarto.yml
+++ b/.github/workflows/build_quarto.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   render:
-    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml
+    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml@jpf/fix-actions
     with:
       build_all: false
       save_build: true

--- a/.github/workflows/build_quarto.yml
+++ b/.github/workflows/build_quarto.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   render:
-    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml@jpf/fix-actions
+    uses: ./.github/workflows/render_quarto.yml
     with:
       build_all: false
       save_build: true

--- a/.github/workflows/build_quarto.yml
+++ b/.github/workflows/build_quarto.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   render:
-    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml@main
+    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml
     with:
       build_all: false
       save_build: true

--- a/.github/workflows/build_quarto.yml
+++ b/.github/workflows/build_quarto.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 jobs:
   render:
-    uses: AlgebraicJulia/.github/.github/workflows/render_quarto.yml@main
+    uses: AlgebraicJulia/GATAS-website/.github/workflows/render_quarto.yml@main
     with:
       build_all: false
       save_build: true

--- a/.github/workflows/render_quarto.yml
+++ b/.github/workflows/render_quarto.yml
@@ -1,0 +1,57 @@
+name: Render Quarto Website
+on:
+  workflow_call:
+    inputs:
+      build_all:
+        description: "Whether or not to delete the _freeze directory before rendering"
+        required: true
+        type: boolean
+      save_build:
+        description: "Whether or not to upload _site and _freeze artifacts"
+        required: true
+        type: boolean
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    env:
+      # Work around GR segfault: https://github.com/jheinen/GR.jl/issues/422
+      GKSwstype: nul
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+      - name: Intall LaTeX dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install graphviz pdf2svg dvisvgm
+          quarto install tinytex --update-path
+          tlmgr update --self
+          tlmgr install tikz-cd luatex85
+      - name: Install Julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.8
+      - name: Setup up Julia Project
+        run: |
+          python3 -m pip install jupyter
+          julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate();'
+      - name: Remove frozen posts
+        if: ${{ inputs.build_all }}
+        run: |
+          rm -rf _freeze _site
+      # TODO: IF RENDER FAILS, OPEN NEW ISSUE OF BROKEN POSTS
+      - name: Render Quarto Project
+        uses: quarto-dev/quarto-actions/render@v2
+      - uses: actions/upload-artifact@v3
+        if: ${{ inputs.save_build }}
+        with:
+          name: _site
+          path: _site
+      - uses: actions/upload-artifact@v3
+        if: ${{ inputs.save_build }}
+        with:
+          name: _freeze
+          path: _freeze


### PR DESCRIPTION
The actions are failing because of a 404 in the ubuntu installs. This PR patches the render-quarto.yaml workflow to upgrade ubuntu before installing things. 